### PR TITLE
Bump bindgen version for compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ build = "build.rs"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.51.1"
+bindgen = "0.63.0"


### PR DESCRIPTION
Some new crates (for example `sys_mount`) are starting to require newer versions of bindgen with incompatible `clang-sys` versions, this just bumps up the requirement so they can be used simultaneously.

