### PR TITLE
Fix bindgen compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xenstore-sys"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Mathieu Tarral <mathieu.tarral@protonmail.com>"]
 edition = "2018"
 description = "Rust FFI bindings for libxenstore"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ build = "build.rs"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.68.1"
+bindgen = "^0.49"


### PR DESCRIPTION
Requires `clang-sys = '^0.28'`