### PR TITLE
Enable static linking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         subcommand: ['build', 'clippy', 'test']
+        feature: ['', 'static']
     steps:
       - uses: actions/checkout@v4
 
@@ -19,4 +20,9 @@ jobs:
 
       - run: sudo apt-get install -y libxen-dev
 
-      - run: cargo ${{ matrix.subcommand }}
+      - run: |
+          if [ -z "${{ matrix.feature }}" ]; then
+            cargo ${{ matrix.subcommand }}
+          else
+            cargo ${{ matrix.subcommand }} --features ${{ matrix.feature }}
+          fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ build = "build.rs"
 [build-dependencies]
 bindgen = ">=0.49"
 pkg-config = "0.3.27"
+
+[features]
+# statically link with libxenstore
+static = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ build = "build.rs"
 
 [build-dependencies]
 bindgen = ">=0.49"
+pkg-config = "0.3.27"

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,6 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let is_static = true;
     // use pkg_config to search for xenstore.pc config file
     // disable cargo metadata, we need to configure rustc manually
     // do not use .statik(), since this feature is buggy due to
@@ -23,7 +22,7 @@ fn main() {
     // manually specify xentoolcore, since we have no way to retrieve the "Requires.private" xenstore.pc field
     // from the Library struct returned by pkg_config
     // and we don't use .statik(), see message above
-    if is_static {
+    if cfg!(feature = "static") {
         println!("cargo:rustc-link-lib=static=xenstore");
         println!("cargo:rustc-link-lib=static=xentoolcore");
     } else {

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,34 @@
 extern crate bindgen;
+extern crate pkg_config;
 
 use std::env;
 use std::path::PathBuf;
 
 fn main() {
+    let is_static = true;
+    // use pkg_config to search for xenstore.pc config file
+    // disable cargo metadata, we need to configure rustc manually
+    // do not use .statik(), since this feature is buggy due to
+    // https://github.com/rust-lang/pkg-config-rs/issues/102
+    let xenstore = pkg_config::Config::new()
+        .cargo_metadata(false)
+        .probe("xenstore")
+        .expect("Failed to locate xenstore library");
 
-    // what library to link with
-    println!("cargo:rustc-link-lib=xenstore");
+    // add search path
+    for path in &xenstore.link_paths {
+        println!("cargo:rustc-link-search=native={}", path.display());
+    }
+
+    // manually specify xentoolcore, since we have no way to retrieve the "Requires.private" xenstore.pc field
+    // from the Library struct returned by pkg_config
+    // and we don't use .statik(), see message above
+    if is_static {
+        println!("cargo:rustc-link-lib=static=xenstore");
+        println!("cargo:rustc-link-lib=static=xentoolcore");
+    } else {
+        println!("cargo:rustc-link-lib=xenstore");
+    }
 
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for


### PR DESCRIPTION
Use [pkg-config](https://crates.io/crates/pkg-config) crate to search for `xenstore.pc` and retrieve the `Library` configuration in order to statically link libxenstore, when the `static` feature has been specified.

A couple of bugs and gotchas here

- the [`.statik()`](https://docs.rs/pkg-config/0.3.27/pkg_config/struct.Config.html#method.statik) doesn't have any effect because it's conditioned by the static library being outside of `/usr/lib`. (see https://github.com/rust-lang/pkg-config-rs/issues/102). On top of that, the author couldn't remember why this [restriction](https://github.com/rust-lang/pkg-config-rs/issues/102#issuecomment-623706276) was put in place, and there hasn't been any new release yet that would remove this code
- The [`Library`](https://docs.rs/pkg-config/0.3.27/pkg_config/struct.Library.html) struct returned by pkg-config doesn't expose the `Required.private` field, which is necessary to specify that we need to link with `xentoolcore` as well, since `xenstore` depends on it. So we need to specify this manually. It may break in the future if Xenstore adds or remove any of its dependencies unfortunately